### PR TITLE
Time Out and Refresh Keys

### DIFF
--- a/cdslogviewer/conf/application.conf
+++ b/cdslogviewer/conf/application.conf
@@ -307,6 +307,8 @@ auth {
   tokenSigningCertPath = ${?JWT_PUBLIC_CERT_PATH}
   adminClaim = "multimedia_admin"
   adminClaim = ${?ADMIN_CLAIM_NAME}
+  keyTimeOut = 86400
+  keyTimeOut = ${?KEY_TIME_OUT}
 }
 
 deployment-root = ${?DEPLOYMENT_ROOT}


### PR DESCRIPTION
## What does this change?

Times out keys after a certain amount of seconds and attempts to download new keys before they are used.

## How can we measure success?

Keys should be invalid less often.

This was tested on a machine running macOS 12.6.8 under minikube 1.31.2 and on the dev. system.